### PR TITLE
feat/ごちゃ混ぜモードの説明ボタンを追加

### DIFF
--- a/frontend/src/app/gachaHome/components/DescriptionModal.tsx
+++ b/frontend/src/app/gachaHome/components/DescriptionModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface ModalProps {
+  onClose: () => void;
+}
+
+const DescriptionModal: React.FC<ModalProps> = ({ onClose }) => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gray-700 bg-opacity-50 z-50">
+      <div className="bg-white rounded-xl p-6 w-80 shadow-lg">
+        <h2 className="text-center text-xl font-bold mb-4">ごちゃ混ぜモードって？？</h2>
+        <p className="text-center text-sm mb-6">
+          じぶん以外のユーザーが追加した<br/>「やりたいこと」をガチャに混ぜて回せるモードのことだよ！<br/>新たなアソビに出会えるかも！？
+        </p>
+        <div className="flex justify-center">
+          <button
+            onClick={onClose}
+            className="py-2 px-6 bg-black text-white rounded-full text-sm"
+          >
+            とじる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DescriptionModal;

--- a/frontend/src/app/gachaHome/components/DescriptionModal.tsx
+++ b/frontend/src/app/gachaHome/components/DescriptionModal.tsx
@@ -4,7 +4,10 @@ interface ModalProps {
   onClose: () => void;
 }
 
+
+
 const DescriptionModal: React.FC<ModalProps> = ({ onClose }) => {
+
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-gray-700 bg-opacity-50 z-50">
       <div className="bg-white rounded-xl p-6 w-80 shadow-lg">

--- a/frontend/src/app/gachaHome/page.tsx
+++ b/frontend/src/app/gachaHome/page.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import Modal from './components/Modal';
+import DescriptionModal from './components/DescriptionModal';
 import Image from 'next/image';
 
 const GachaHome: React.FC = () => {
   const [isMixMode, setIsMixMode] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDesModalOpen, setIsDesModalOpen] = useState(false);
   const [apiResponse, setApiResponse] = useState(null);
   const [timeCategory, setTimeCategory] = useState(0);
 
@@ -128,9 +130,11 @@ const GachaHome: React.FC = () => {
           <button
               className="flex items-center justify-center w-6 h-6 rounded-full bg-white text-xs text-black mr-2 border border-black"
               aria-label="ごちゃ混ぜモードの説明"
+              onClick={() => setIsDesModalOpen(true)}
             >
             ?
           </button>
+          {isDesModalOpen && <DescriptionModal onClose={() => setIsDesModalOpen(false)} />}
 
           <span className="text-lg">ごちゃ混ぜモード</span>
           <input type="checkbox" className="toggle-checkbox hidden" id="toggle" checked={isMixMode} onChange={handleToggle} />


### PR DESCRIPTION
### 概要
/gachaHomeにおいて?ボタンを押した時のごちゃ混ぜモードの説明を作りました
<!-- 変更の目的や内容について簡潔に説明してください -->

### 変更内容
- gachaHome/page.tsxにmodalを呼び出すように変更
- gachaHome/components/DescrptionModal.tsxを追加
<!-- 具体的にどのような変更を行ったのか記載してください -->

### テスト手順

<!-- 動作確認の方法を具体的に記載してください -->

1. /gachaHomeで?ボタンを押してください

### レビュー観点
デザイン良さげか
<!-- 特にレビューして欲しい箇所や、不安な点があれば記載してください -->

### チェックリスト

- [x] コード実行して問題ないことを確認
- [x] 必要なレビューアをアサインした
- [ ] (必要であれば)ドキュメントを更新した
